### PR TITLE
chore: add GoogleService-Info.plist to .gitignore for security reasons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+GoogleService-Info.plist
+


### PR DESCRIPTION
This includes adding GoogleService-Info.plist to the .gitignore file to enhance security by excluding sensitive Firebase configuration from version control.
As the app development nears completion, a final review will be conducted to consider re-implementing the Google Sign-In feature.
This approach ensures the app remains secure during development while keeping the option open for future authentication enhancements.